### PR TITLE
fix specificity issue since new discord update

### DIFF
--- a/src/server-list.scss
+++ b/src/server-list.scss
@@ -1,7 +1,7 @@
 $serverListWidth: 72px;
 
 :root {
-  .guilds_c48ade {
+  .wrapper_ef3116.guilds_c48ade {
     background-color: var(--background-tertiary);
 
     .listItem__650eb {


### PR DESCRIPTION
New update introduced an issue with the specificity of the styling of the server list for people in the fast follows experiment

Experiment: 2025-04_desktop_refresh_fast_follows